### PR TITLE
Treat only '=' as an ini delimiter

### DIFF
--- a/nm2nix.py
+++ b/nm2nix.py
@@ -8,7 +8,7 @@ nmfiles = [f for f in files if f.endswith(".nmconnection")]
 
 print("{")
 for i in nmfiles:
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(delimiters=('=', ))
     config.read(i)
     connection_name = i.strip(".nmconnection")
     print(f"  {connection_name} = {{")


### PR DESCRIPTION
By default both `:` and `=` are treated as delimiters by ConfigParser, but NetworkManager only treats `=` as a delimiter and uses `:` in key names.