### PR TITLE
Use removesuffix instead of strip

### DIFF
--- a/nm2nix.py
+++ b/nm2nix.py
@@ -10,7 +10,7 @@ print("{")
 for i in nmfiles:
     config = configparser.ConfigParser(delimiters=('=', ))
     config.read(i)
-    connection_name = i.strip(".nmconnection")
+    connection_name = i.removesuffix(".nmconnection")
     print(f"  {connection_name} = {{")
     for section in config.sections():
         print(f"    {section} = {{")


### PR DESCRIPTION
Strip treats the argument as a list of characters to remove across the whole string. What we really want is removesuffix