### PR TITLE
Refactor JSON to Nix handling

### DIFF
--- a/nm2nix.py
+++ b/nm2nix.py
@@ -1,4 +1,4 @@
-from os import listdir, getpid
+from os import listdir
 from subprocess import check_output
 from os.path import isfile, join
 import configparser
@@ -22,9 +22,7 @@ for i in nmfiles:
         for key in config[section]:
             jsonConfigs[connection_name][section][key] = config[section][key]
 
-tf = tempfile.TemporaryFile("w+")
-jsonConfigs = json.dump(jsonConfigs, tf)
-tf.flush()
-
-
-print(check_output(["nix-instantiate", "--expr", "--eval",  f"builtins.fromJSON (builtins.readFile \"/proc/{getpid()}/fd/{tf.fileno()}\")"], text=True))  # noqa: E501
+with tempfile.NamedTemporaryFile(mode="w") as tf:
+    tf.write(json.dumps(jsonConfigs))
+    tf.flush()
+    print(check_output(["nix-instantiate", "--expr", "--eval",  f"builtins.fromJSON (builtins.readFile \"{tf.name}\")"], text=True))  # noqa: E501


### PR DESCRIPTION
This commit a) fixes issue #8, and b) wraps the `nix-instantiate` call in a Python `with` block, which is easier to read than using `procfs`. It also means the `nix-instantiate` call is portable.

~~I think if you merged this PR, then created a separate tool for Lix based on `nm2nix`, then people have the best of both worlds.~~

EDIT: In the strike through above, I fundamentally misunderstood how Lix and other Nix forks work - they do seem to retain some level of compatibility, if not all, with Nix, so there's no need for a separate tool. The only thing taht would need adjusting would be the documentation.