### PR TITLE
Fix interpolation error with % character

### DIFF
--- a/nm2nix.py
+++ b/nm2nix.py
@@ -13,7 +13,7 @@ nmfiles = [f for f in files if f.endswith(".nmconnection")]
 jsonConfigs = {}
 
 for i in nmfiles:
-    config = configparser.ConfigParser(delimiters=('=', ))
+    config = configparser.ConfigParser(delimiters=('=', ), interpolation=None)
     config.read(i)
     connection_name = i.removesuffix(".nmconnection")
     jsonConfigs[connection_name] = {}


### PR DESCRIPTION
Configparser normally treats % as an escape character, but it isn't in this case, this can be fixed by setting `interpolation=None`.

see: https://stackoverflow.com/questions/14340366/configparser-and-string-with

Fixes the following error:

```
Traceback (most recent call last):
  File "/nix/store/fylx0gshxxbkyyxzabd7bcv5wd2kl705-nm2nix/bin/nm2nix", line 24, in <module>
    jsonConfigs[connection_name][section][key] = config[section][key]
                                                 ~~~~~~~~~~~~~~~^^^^^
  File "/nix/store/w4fvvhkzb0ssv0fw5j34pw09f0qw84w8-python3-3.11.7/lib/python3.11/configparser.py", line 1274, in __getitem__
    return self._parser.get(self._name, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/w4fvvhkzb0ssv0fw5j34pw09f0qw84w8-python3-3.11.7/lib/python3.11/configparser.py", line 815, in get
    return self._interpolation.before_get(self, section, option, value,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/w4fvvhkzb0ssv0fw5j34pw09f0qw84w8-python3-3.11.7/lib/python3.11/configparser.py", line 396, in before_get
    self._interpolate_some(parser, option, L, value, section, defaults, 1)
  File "/nix/store/w4fvvhkzb0ssv0fw5j34pw09f0qw84w8-python3-3.11.7/lib/python3.11/configparser.py", line 443, in _interpolate_some
    raise InterpolationSyntaxError(
configparser.InterpolationSyntaxError: '%' must be followed by '%' or '(', found: '<password with % in it>'
```